### PR TITLE
chore: cleanup tryradi.us references

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -144,7 +144,7 @@ WALLET_PRIVATE_KEY=your_wallet_private_key_here
 
 Note:
 - Get an OpenAI API key from: https://platform.openai.com/api-keys
-- RPC provider URL from Radius testnet: https://testnet.tryradi.us/dashboard/rpc-endpoints
+- RPC provider URL from Radius testnet: https://testnet.radiustech.xyz/dashboard/rpc-endpoints
 - The wallet private key should be from an EVM-compatible wallet
 
 #### 5. Run the Example

--- a/python/examples/README.md
+++ b/python/examples/README.md
@@ -22,7 +22,7 @@ Each example is a self-contained package with its own README, setup instructions
 
 All examples require:
 - Python >=3.10
-- A Radius wallet with ETH (obtain from the [Radius faucet](https://testnet.tryradi.us/dashboard/faucet))
+- A Radius wallet with ETH (obtain from the [Radius faucet](https://testnet.radiustech.xyz/dashboard/faucet))
 - API keys for specific services (OpenAI, Uniswap, etc.)
 
 ## Learning Path
@@ -35,7 +35,7 @@ If you're new to the Radius AI Agent SDK:
 
 ## Resources
 
-- [Radius Documentation](https://docs.tryradi.us)
+- [Radius Documentation](https://docs.radiustech.xyz)
 - [AI Agent Toolkit](https://github.com/radiustechsystems/ai-agent-toolkit)
 - [Website](https://radiustech.xyz/)
 - [Testnet Access](https://docs.radiustech.xyz/radius-testnet-access)

--- a/python/examples/langchain/uniswap/README.md
+++ b/python/examples/langchain/uniswap/README.md
@@ -14,7 +14,7 @@ This example demonstrates how to build AI agents that can interact with the Unis
 
 - Python >=3.10
 - An OpenAI API key for LLM access
-- A Radius wallet with ETH (obtain from the [Radius faucet](https://testnet.tryradi.us/dashboard/faucet))
+- A Radius wallet with ETH (obtain from the [Radius faucet](https://testnet.radiustech.xyz/dashboard/faucet))
 - Uniswap API key
 - Radius RPC endpoint URL
 
@@ -90,7 +90,7 @@ tools = get_on_chain_tools(
 
 ## Learn More
 
-- [Radius Documentation](https://docs.tryradi.us)
+- [Radius Documentation](https://docs.radiustech.xyz)
 - [AI Agent Toolkit](https://github.com/radiustechsystems/ai-agent-toolkit)
 - [Uniswap Documentation](https://docs.uniswap.org/)
 - [LangChain Documentation](https://python.langchain.com/docs/get_started)

--- a/python/examples/langchain/web3/README.md
+++ b/python/examples/langchain/web3/README.md
@@ -14,7 +14,7 @@ This example demonstrates how to integrate LangChain agents with Web3.py using t
 
 - Python >=3.10
 - An OpenAI API key for LLM access
-- A Radius wallet with ETH (obtain from the [Radius faucet](https://testnet.tryradi.us/dashboard/faucet))
+- A Radius wallet with ETH (obtain from the [Radius faucet](https://testnet.radiustech.xyz/dashboard/faucet))
 - Radius RPC endpoint URL
 
 ## Installation
@@ -82,7 +82,7 @@ tools = get_on_chain_tools(
 
 ## Learn More
 
-- [Radius Documentation](https://docs.tryradi.us)
+- [Radius Documentation](https://docs.radiustech.xyz)
 - [AI Agent Toolkit](https://github.com/radiustechsystems/ai-agent-toolkit)
 - [LangChain Documentation](https://python.langchain.com/docs/get_started)
 - [Web3.py Documentation](https://web3py.readthedocs.io/)

--- a/typescript/examples/micropayments/vercel-ai/README.md
+++ b/typescript/examples/micropayments/vercel-ai/README.md
@@ -15,7 +15,7 @@ This example demonstrates a real-time AI content generation platform with instan
 ### Prerequisites
 
 1. Node.js (v18+) and pnpm installed
-2. A Radius wallet with some ETH (obtain from the [Radius faucet](https://testnet.tryradi.us/dashboard/faucet))
+2. A Radius wallet with some ETH (obtain from the [Radius faucet](https://testnet.radiustech.xyz/dashboard/faucet))
 3. Anthropic API key for Claude models
 
 ### Setup
@@ -60,7 +60,7 @@ This example shows how Radius enables new business models for AI:
 
 ## Learn More
 
-- [Radius Documentation](https://docs.tryradi.us)
+- [Radius Documentation](https://docs.radiustech.xyz)
 - [AI Agent Toolkit](https://github.com/radiustechsystems/ai-agent-toolkit)
 - [Anthropic Claude API](https://docs.anthropic.com/claude/reference/getting-started-with-the-api)
 - [Vercel AI SDK](https://sdk.vercel.ai/docs)


### PR DESCRIPTION
Updating references for `tryradi.us` to `radiustech.xyz`
